### PR TITLE
Fix NameError: import Optional in ankh_transformer_utils

### DIFF
--- a/enzymeexplorer/src/embeddings_extraction/ankh_transformer_utils.py
+++ b/enzymeexplorer/src/embeddings_extraction/ankh_transformer_utils.py
@@ -1,4 +1,6 @@
 """This script contains utils for Ankh embeddings extraction"""
+from typing import Optional
+
 import ankh  # type: ignore
 import numpy as np  # type: ignore
 import torch  # type: ignore


### PR DESCRIPTION
## Problem
`enzymeexplorer/src/embeddings_extraction/ankh_transformer_utils.py` annotates
`checkpoint_dir: Optional[str]` in `get_model_and_tokenizer()` (line 9) but never
imports `Optional`. Python evaluates that annotation at function-definition time,
so importing the module raises:

```
NameError: name 'Optional' is not defined
```

`tps_predict_fasta.py` imports this module, so the **sequence-only prediction
path crashes on import** — the PLM detection step produces nothing, and the
downstream `gather_detections_to_csv.py` then fails with
`AssertionError: ... detections_plm does not exist`.

## Fix
Add `from typing import Optional`. One line.

## Verification
With the fix, `easy_predict_sequence_only.py` runs end-to-end on a 2-sequence
FASTA and produces the expected CSV (substrate-class probabilities + `isTPS` +
`ID`). Without it, the run fails as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)