### PR TITLE
Fix foldseek post-processor ID collapse for underscored IDs

### DIFF
--- a/app_faster_with_foldseek.py
+++ b/app_faster_with_foldseek.py
@@ -191,7 +191,7 @@ async def upload_file(file: UploadFile = File(...),
 
         for detected_domain_id in comparison_results[pdb_id]:
             detected_domain_file_path = detected_domain_structures_root / f"{detected_domain_id}.pdb"
-            pdb_id_current = detected_domain_id.split('_')[0]
+            pdb_id_current = detected_domain_id.rsplit('_', 2)[0]
             closest_known_domain_id, foldseek_tm_score = max([(known_domain_id, tmscore)
                                                               for known_domain_id, tmscore in comparison_results[pdb_id][detected_domain_id]
                                                               if known_domain_id.split('_')[0] != pdb_id_current and known_domain_id.split('_')[0] in id_2_domain_config],

--- a/enzymeexplorer/src/structure_processing/comparing_to_known_domains_foldseek.py
+++ b/enzymeexplorer/src/structure_processing/comparing_to_known_domains_foldseek.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     for _, row in df_foldseek.iterrows():
         if row['target'] in dom_subset:
-            uni_id = row['query'].split('_')[0]
+            uni_id = row['query'].rsplit('_', 2)[0]
             if uni_id not in filename_2_regions_vs_known_reg_dists:
                 filename_2_regions_vs_known_reg_dists[uni_id] = defaultdict(list)
             filename_2_regions_vs_known_reg_dists[uni_id][row['query']].append([row['target'], float(row['alntmscore'])])


### PR DESCRIPTION
## Summary

The foldseek post-processor in `enzymeexplorer/src/structure_processing/comparing_to_known_domains_foldseek.py` used `row['query'].split('_')[0]` to recover the source protein ID from a foldseek hit. The `query` field is internally constructed as `f"{filename_stem}_{domain}_{i}"` (with `domain ∈ {alpha, alphaWeird, beta, gamma, delta, epsilon}` and `i` an integer — neither piece contains an underscore), so any input ID containing an underscore was collapsed to just its prefix, breaking the per-protein lookup in `scripts/easy_predict.py`. Switching to `rsplit('_', 2)[0]` deterministically peels off the trailing `_{domain}_{i}` suffix and recovers the original `filename_stem`, whether or not it contains underscores.

## Test table

| `query` | before (`split('_')[0]`) | after (`rsplit('_', 2)[0]`) | expected |
|---|---|---|---|
| `Q7Z859_alpha_0` | `Q7Z859` | `Q7Z859` | `Q7Z859` |
| `marts_E00000_beta_3` | `marts` | `marts_E00000` | `marts_E00000` |
| `dplm2_150m_phase1_unconditional_001_alpha_5` | `dplm2` | `dplm2_150m_phase1_unconditional_001` | `dplm2_150m_phase1_unconditional_001` |

## Why `rsplit('_', 2)[0]` is robust

Because the `query` is constructed in this codebase as `{filename_stem}_{domain}_{i}` and **both** suffix pieces are underscore-free by construction (`domain` is one of six fixed words, `i` is an integer), splitting from the right exactly twice always cleaves off the suffix and leaves `filename_stem` intact — even when `filename_stem` itself contains arbitrarily many underscores.

## Second commit

A second commit applies the same fix to the legacy Streamlit app `app_faster_with_foldseek.py` (not invoked by `easy_predict.py`), where `detected_domain_id.split('_')[0]` had the same collapse pattern. The neighbouring `known_domain_id.split('_')[0]` and `closest_known_domain_id.split('_')[0]` calls are intentionally **left as-is** — known-domain IDs are bare Uniprot accessions without underscores, so that split is correct for them.

## Observed impact

- MARTS-DB run (Karolina job `4446182`): 1317 foldseek-level domain hits but **0/1319** per-protein assignments, because all `query` values collapsed to the shared prefix `"marts"`.
- All 28 `model_exploration` generation configs hit the same failure mode for the same reason.

After this fix, both reproduce per-protein lookups correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)